### PR TITLE
feat: simple `instructor-rs` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["instruct_model", "instruct_model_derive", "instructor_rs"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ let user = ChatCompletionRequest::new(
 println!("{}", UserInfo.name) // John Doe
 println!("{}", UserInfo.age)  // 30
 ```
+
+
+## How to run examples
+
+Try out the `readme`, `simple` and `weather` examples by running the following commands:
+
+```bash
+OPENAI_API_KEY=sk-your-key \
+cargo run -p instructor-rs \
+--example simple
+```
+
+## Note
+
+This implementation is 100% in development was just hacked together for reference and to explore the api shown on the readme. It is not intended to be used in production, and likely misses a lot of the projects core features.

--- a/instruct_model/Cargo.toml
+++ b/instruct_model/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "instruct_model"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1.80"
+instruct_model_derive = { path = "../instruct_model_derive" }
+reqwest = { version = "0.12.5", features = ["json"] }
+serde_json = "1.0.117"
+serde = { version = "1.0", features = ["derive"] }

--- a/instruct_model/src/lib.rs
+++ b/instruct_model/src/lib.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use async_trait::async_trait;
+pub use instruct_model_derive::InstructModel;
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+const GPT_3_5_TURBO: &str = "gpt-3.5-turbo";
+// const GPT_4_O: &str = "gpt-4o";
+
+#[async_trait]
+pub trait InstructModel: Sized {
+    async fn extract_from_response(response: ChatCompletionResponse) -> Result<Self>;
+}
+
+pub struct Instructor {
+    client: Client,
+}
+
+impl Instructor {
+    pub fn from_openai(api_key: String) -> Self {
+        let client = Client::builder()
+            .default_headers({
+                let mut headers = reqwest::header::HeaderMap::new();
+                headers.insert(
+                    "Authorization",
+                    format!("Bearer {}", api_key).parse().unwrap(),
+                );
+                headers.insert(
+                    reqwest::header::CONTENT_TYPE,
+                    "application/json".parse().unwrap(),
+                );
+                headers
+            })
+            .build()
+            .unwrap();
+        Instructor { client }
+    }
+
+    pub async fn extract<T: InstructModel + DeserializeOwned>(&self, prompt: &str) -> Result<T> {
+        let request = ChatCompletionRequest {
+            model: GPT_3_5_TURBO.to_string(),
+            messages: vec![
+                ChatCompletionMessage {
+                    role: "system".to_string(),
+                    content: "You are a helpful assistant. Please respond with valid JSON for the shared struct.".to_string(),
+                },
+                ChatCompletionMessage {
+                    role: "user".to_string(),
+                    content: prompt.to_string(),
+                },
+            ],
+        };
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/chat/completions")
+            .json(&request)
+            .send()
+            .await?
+            .json::<ChatCompletionResponse>()
+            .await?;
+        T::extract_from_response(response).await
+    }
+}
+
+#[derive(Serialize)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatCompletionMessage>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ChatCompletionMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Deserialize)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<ChatCompletionChoice>,
+    pub usage: ChatCompletionUsage,
+}
+
+#[derive(Deserialize)]
+pub struct ChatCompletionChoice {
+    pub index: u32,
+    pub message: ChatCompletionMessage,
+    pub finish_reason: String,
+}
+
+#[derive(Deserialize)]
+pub struct ChatCompletionUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}

--- a/instruct_model_derive/Cargo.toml
+++ b/instruct_model_derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "instruct_model_derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/instruct_model_derive/src/lib.rs
+++ b/instruct_model_derive/src/lib.rs
@@ -1,0 +1,25 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(InstructModel)]
+pub fn derive_instruct_model(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let expanded = quote! {
+        #[async_trait]
+        impl InstructModel for #name {
+            async fn extract_from_response(response: ChatCompletionResponse) -> Result<Self> {
+                let content = response
+                    .choices
+                    .first()
+                    .ok_or_else(|| anyhow!("No choices in response"))?
+                    .message
+                    .content
+                    .clone();
+                serde_json::from_str(&content).map_err(|e| anyhow!("Failed to parse {}: {}", stringify!(#name), e))
+            }
+        }
+    };
+    TokenStream::from(expanded)
+}

--- a/instructor_rs/Cargo.toml
+++ b/instructor_rs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "instructor-rs"
+version = "0.0.0"
+edition = "2021"
+
+
+[dependencies]
+reqwest = { version = "0.12.5", features = ["json"] }
+async-trait = "0.1.80"
+serde_json = "1.0.117"
+serde = { version = "1.0", features = ["derive"] }
+anyhow = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+quote = "1.0.36"
+syn = "2.0.67"
+instruct_model = { path = "../instruct_model" }

--- a/instructor_rs/examples/readme.rs
+++ b/instructor_rs/examples/readme.rs
@@ -1,0 +1,22 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use instruct_model::{ChatCompletionResponse, InstructModel, Instructor};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, InstructModel)]
+struct UserInfo {
+    name: String,
+    age: u8,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Instructor::from_openai(std::env::var("OPENAI_API_KEY")?);
+
+    let prompt = "Extract user info from: John Doe is 30 years old";
+    let user_info: UserInfo = client.extract(prompt).await?;
+    println!("Name: {}", user_info.name);
+    println!("Age: {}", user_info.age);
+
+    Ok(())
+}

--- a/instructor_rs/examples/simple.rs
+++ b/instructor_rs/examples/simple.rs
@@ -1,0 +1,34 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use instruct_model::{ChatCompletionResponse, InstructModel, Instructor};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, InstructModel)]
+struct SuperheroInfo {
+    alias: String,
+    real_name: String,
+    superpower: String,
+    age: u8,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Instructor::from_openai(std::env::var("OPENAI_API_KEY")?);
+
+    let prompt = &format!(
+        "Extract superhero info from: The superhero known as 'Shadow Phantom' is actually Jane Doe, who possesses the power of invisibility and is 30 years old. The object should be {}",
+        serde_json::to_string(&SuperheroInfo {
+            alias: "Shadow Phantom".to_string(),
+            real_name: "Jane Doe".to_string(),
+            superpower: "invisibility".to_string(),
+            age: 28,
+        })?
+    );
+    let superhero_info: SuperheroInfo = client.extract(prompt).await?;
+    println!("Alias: {}", superhero_info.alias);
+    println!("Real Name: {}", superhero_info.real_name);
+    println!("Superpower: {}", superhero_info.superpower);
+    println!("Age: {}", superhero_info.age);
+
+    Ok(())
+}

--- a/instructor_rs/examples/weather.rs
+++ b/instructor_rs/examples/weather.rs
@@ -1,0 +1,41 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use instruct_model::{ChatCompletionResponse, InstructModel, Instructor};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, InstructModel)]
+struct WeatherForecast {
+    date: String,
+    temperature_c: i32,
+    temperature_f: i32,
+    details: WeatherDetails,
+}
+
+#[derive(Debug, Serialize, Deserialize, InstructModel)]
+struct WeatherDetails {
+    avg_humidity: i32,
+    avg_wind_speed: i32,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Instructor::from_openai(std::env::var("OPENAI_API_KEY")?);
+    let prompt = &format!(
+        "Extract weather forecast from: On 2022-01-01, the temperature is 20C and 68F, with an average humidity of 50% and an average wind speed of 10 mph. Example object {}",
+        serde_json::to_string(&WeatherForecast {
+            date: "2022-01-01".to_string(),
+            temperature_c: 20,
+            temperature_f: 68,
+            details: WeatherDetails {
+                avg_humidity: 50,
+                avg_wind_speed: 10,
+            },
+        })?
+    );
+    let weather_forecast: WeatherForecast = client.extract(prompt).await?;
+    println!("Date: {}", weather_forecast.date);
+    println!("Temperature (C): {}", weather_forecast.temperature_c);
+    println!("Temperature (F): {}", weather_forecast.temperature_f);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is a simple implementation of `instructor-rs` hacked together to (mostly) meet the example shown on the readme.

The readme example can be run with the following command

```bash
OPENAI_API_KEY=sk-your-key \
cargo run -p instructor-rs \
--example readme
```

This implementation is simple and misses many of the great features of instructor. The main goal was to simply to put together a small mvp and share anything that may be helpful to this project's future