### PR TITLE
Added support for Option types

### DIFF
--- a/instruct-macros-types/src/lib.rs
+++ b/instruct-macros-types/src/lib.rs
@@ -18,6 +18,28 @@ impl InstructMacroResult {
             InstructMacroResult::Enum(enum_info) => enum_info.wrap_info(new_name),
         }
     }
+
+    pub fn override_description(self, new_description: String) -> InstructMacroResult {
+        match self {
+            InstructMacroResult::Struct(struct_info) => {
+                InstructMacroResult::Struct(struct_info.override_description(new_description))
+            }
+            InstructMacroResult::Enum(enum_info) => {
+                InstructMacroResult::Enum(enum_info.override_description(new_description))
+            }
+        }
+    }
+
+    pub fn set_optional(self, is_optional: bool) -> InstructMacroResult {
+        match self {
+            InstructMacroResult::Struct(struct_info) => {
+                InstructMacroResult::Struct(struct_info.set_optional(is_optional))
+            }
+            InstructMacroResult::Enum(enum_info) => {
+                InstructMacroResult::Enum(enum_info.set_optional(is_optional))
+            }
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -25,12 +47,25 @@ pub struct StructInfo {
     pub name: String,
     pub description: String,
     pub parameters: Vec<Parameter>,
+    pub is_optional: bool,
 }
 
 impl StructInfo {
     pub fn wrap_info(mut self, new_name: String) -> Parameter {
         self.name = new_name;
         Parameter::Struct(self)
+    }
+
+    pub fn override_description(mut self, new_description: String) -> StructInfo {
+        if new_description.len() > 0 {
+            self.description = new_description;
+        }
+        self
+    }
+
+    pub fn set_optional(mut self, is_optional: bool) -> StructInfo {
+        self.is_optional = is_optional;
+        self
     }
 }
 
@@ -46,6 +81,7 @@ pub struct ParameterInfo {
     pub name: String,
     pub r#type: String,
     pub comment: String,
+    pub is_optional: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -54,12 +90,25 @@ pub struct EnumInfo {
     pub r#enum: Vec<String>,
     pub r#type: String,
     pub description: String,
+    pub is_optional: bool,
 }
 
 impl EnumInfo {
     pub fn wrap_info(mut self, new_name: String) -> Parameter {
         self.title = new_name;
         Parameter::Enum(self)
+    }
+
+    pub fn override_description(mut self, new_description: String) -> EnumInfo {
+        if new_description.len() > 0 {
+            self.description = new_description;
+        }
+        self
+    }
+
+    pub fn set_optional(mut self, is_optional: bool) -> EnumInfo {
+        self.is_optional = is_optional;
+        self
     }
 }
 
@@ -68,4 +117,5 @@ pub struct FieldInfo {
     pub description: String,
     pub r#type: String,
     pub is_complex: bool,
+    pub is_optional: bool,
 }

--- a/instruct-macros/src/lib.rs
+++ b/instruct-macros/src/lib.rs
@@ -40,6 +40,7 @@ fn generate_instruct_macro_enum(input: &DeriveInput) -> proc_macro2::TokenStream
             r#enum: vec![#(#enum_variants.to_string()),*],
             r#type: stringify!(#name).to_string(),
             description: #description.to_string(),
+            is_optional:false
         })
     };
 
@@ -121,6 +122,7 @@ fn generate_instruct_macro_struct(input: &DeriveInput) -> proc_macro2::TokenStre
                     name: stringify!(#name).to_string(),
                     description: #description.to_string(),
                     parameters,
+                    is_optional:false
                 })
             }
 

--- a/instruct-macros/tests/integration_test.rs
+++ b/instruct-macros/tests/integration_test.rs
@@ -36,13 +36,16 @@ mod tests {
                     name: "field1".to_string(),
                     r#type: "String".to_string(),
                     comment: "This is a sample example that spans across three lines".to_string(),
+                    is_optional: false,
                 }),
                 Parameter::Field(ParameterInfo {
                     name: "field2".to_string(),
                     r#type: "str".to_string(),
                     comment: "This is a test field".to_string(),
+                    is_optional: false,
                 }),
             ],
+            is_optional: false,
         };
 
         let info_struct = match info {
@@ -117,11 +120,13 @@ mod tests {
                     name: "name".to_string(),
                     r#type: "String".to_string(),
                     comment: "".to_string(),
+                    is_optional: false,
                 }),
                 Parameter::Field(ParameterInfo {
                     name: "age".to_string(),
                     r#type: "u8".to_string(),
                     comment: "".to_string(),
+                    is_optional: false,
                 }),
                 Parameter::Struct(StructInfo {
                     name: "address".to_string(),
@@ -131,15 +136,19 @@ mod tests {
                             name: "street".to_string(),
                             r#type: "String".to_string(),
                             comment: "".to_string(),
+                            is_optional: false,
                         }),
                         Parameter::Field(ParameterInfo {
                             name: "city".to_string(),
                             r#type: "String".to_string(),
                             comment: "".to_string(),
+                            is_optional: false,
                         }),
                     ],
+                    is_optional: false,
                 }),
             ],
+            is_optional: false,
         };
 
         let info_struct = match info {
@@ -171,6 +180,7 @@ mod tests {
             ],
             r#type: "Status".to_string(),
             description: "".to_string(),
+            is_optional: false,
         };
 
         let info_enum = match info {
@@ -209,6 +219,7 @@ mod tests {
                     name: "name".to_string(),
                     r#type: "String".to_string(),
                     comment: "".to_string(),
+                    is_optional: false,
                 }),
                 Parameter::Enum(EnumInfo {
                     title: "status".to_string(),
@@ -219,8 +230,10 @@ mod tests {
                     ],
                     r#type: "Status".to_string(),
                     description: "This is an enum representing the status of a person".to_string(),
+                    is_optional: false,
                 }),
             ],
+            is_optional: false,
         };
 
         let info_struct = match info {

--- a/instruct-macros/tests/test_option.rs
+++ b/instruct-macros/tests/test_option.rs
@@ -1,0 +1,106 @@
+extern crate instruct_macros_types;
+
+use instruct_macros::InstructMacro;
+use instruct_macros_types::{
+    InstructMacro, InstructMacroResult, Parameter, ParameterInfo, StructInfo,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_option_type_support() {
+        #[derive(InstructMacro, Debug)]
+        #[allow(dead_code)]
+        #[description("This is a struct with Option types")]
+        struct TestOptionStruct {
+            #[description("This is an optional string field")]
+            pub field1: Option<String>,
+            #[description("This is an optional integer field")]
+            pub field2: Option<i32>,
+        }
+
+        let info = TestOptionStruct::get_info();
+        let desired_struct = StructInfo {
+            name: "TestOptionStruct".to_string(),
+            description: "This is a struct with Option types".to_string(),
+            is_optional: false,
+            parameters: vec![
+                Parameter::Field(ParameterInfo {
+                    name: "field1".to_string(),
+                    r#type: "Option<String>".to_string(),
+                    comment: "This is an optional string field".to_string(),
+                    is_optional: true,
+                }),
+                Parameter::Field(ParameterInfo {
+                    name: "field2".to_string(),
+                    r#type: "Option<i32>".to_string(),
+                    comment: "This is an optional integer field".to_string(),
+                    is_optional: true,
+                }),
+            ],
+        };
+
+        let info_struct = match info {
+            InstructMacroResult::Struct(s) => s,
+            _ => panic!("Expected StructInfo"),
+        };
+
+        assert_eq!(info_struct, desired_struct);
+    }
+
+    #[test]
+    fn test_option_maybe_struct() {
+        #[derive(InstructMacro, Debug)]
+        #[allow(dead_code)]
+        #[description("This is a user struct")]
+        struct User {
+            #[description("This is the user's name")]
+            pub name: String,
+            #[description("This is the user's age")]
+            pub age: i32,
+        }
+
+        #[derive(InstructMacro, Debug)]
+        #[allow(dead_code)]
+        #[description("This is a struct with Option<user> type")]
+        struct MaybeUser {
+            #[description("This is an optional user field")]
+            pub user: Option<User>,
+        }
+
+        let info = MaybeUser::get_info();
+        let desired_struct = StructInfo {
+            name: "MaybeUser".to_string(),
+            description: "This is a struct with Option<user> type".to_string(),
+            parameters: vec![Parameter::Struct(StructInfo {
+                name: "user".to_string(),
+                description: "This is an optional user field".to_string(),
+                parameters: vec![
+                    Parameter::Field(ParameterInfo {
+                        name: "name".to_string(),
+                        r#type: "String".to_string(),
+                        comment: "This is the user's name".to_string(),
+                        is_optional: false,
+                    }),
+                    Parameter::Field(ParameterInfo {
+                        name: "age".to_string(),
+                        r#type: "i32".to_string(),
+                        comment: "This is the user's age".to_string(),
+                        is_optional: false,
+                    }),
+                ],
+                is_optional: true,
+            })],
+            is_optional: false,
+        };
+
+        let info_struct = match info {
+            InstructMacroResult::Struct(s) => s,
+            _ => panic!("Expected StructInfo"),
+        };
+
+        assert_eq!(info_struct, desired_struct);
+    }
+}

--- a/instructor/src/helpers/response_model.rs
+++ b/instructor/src/helpers/response_model.rs
@@ -1,20 +1,27 @@
 use std::collections::HashMap;
 
-use instruct_macros_types::{Parameter, StructInfo};
+use instruct_macros_types::{Parameter, ParameterInfo, StructInfo};
 use openai_api_rs::v1::chat_completion::{self, JSONSchemaDefine};
 
 fn get_required_properties(info: &StructInfo) -> Vec<String> {
     let mut required = Vec::new();
+
     for param in info.parameters.iter() {
         match param {
             Parameter::Field(field_info) => {
-                required.push(field_info.name.clone());
+                if !field_info.is_optional {
+                    required.push(field_info.name.clone());
+                }
             }
             Parameter::Struct(struct_info) => {
-                required.push(struct_info.name.clone());
+                if !struct_info.is_optional {
+                    required.push(struct_info.name.clone());
+                }
             }
             Parameter::Enum(enum_info) => {
-                required.push(enum_info.title.clone());
+                if !enum_info.is_optional {
+                    required.push(enum_info.title.clone());
+                }
             }
         }
     }
@@ -27,7 +34,16 @@ fn convert_parameter_type(info: &str) -> chat_completion::JSONSchemaType {
         "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "u64" | "i64" | "u128" | "i128" | "usize"
         | "isize" => chat_completion::JSONSchemaType::Number,
         "bool" => chat_completion::JSONSchemaType::Boolean,
+
         _ => panic!("Unsupported type: {}", info),
+    }
+}
+
+fn get_base_type(field_info: &ParameterInfo) -> &str {
+    if field_info.r#type.starts_with("Option<") && field_info.r#type.ends_with('>') {
+        &field_info.r#type[7..field_info.r#type.len() - 1]
+    } else {
+        &field_info.r#type
     }
 }
 
@@ -40,7 +56,8 @@ fn get_response_model_parameters(t: &StructInfo) -> HashMap<String, Box<JSONSche
                 let parameter_name = field_info.name.clone();
                 let parameter_description = field_info.comment.clone();
 
-                let parameter_type = convert_parameter_type(&field_info.r#type.to_string());
+                let base_type = get_base_type(field_info);
+                let parameter_type = convert_parameter_type(&base_type.to_string());
 
                 properties.insert(
                     parameter_name,
@@ -282,10 +299,6 @@ mod tests {
             ]),
         };
 
-        if expected_parameters != parameters {
-            println!("Expected Parameters: {:?}", expected_parameters);
-            println!("Actual Parameters: {:?}", parameters);
-        }
         assert_eq!(expected_parameters, parameters);
     }
 
@@ -333,10 +346,115 @@ mod tests {
             required: Some(vec!["name".to_string(), "age".to_string()]),
         };
 
-        if expected_parameters != parameters {
-            println!("Expected Parameters: {:?}", expected_parameters);
-            println!("Actual Parameters: {:?}", parameters);
+        assert_eq!(expected_parameters, parameters);
+    }
+
+    #[test]
+    fn test_struct_with_optional_field() {
+        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
+        struct StructWithOptionalField {
+            #[description("The name of the user")]
+            name: String,
+            #[description("The age of the user")]
+            age: Option<u8>,
         }
+
+        let struct_info = StructWithOptionalField::get_info();
+        let parsed_model: StructInfo = match struct_info {
+            InstructMacroResult::Struct(info) => info,
+            _ => {
+                panic!("Expected StructInfo but got a different InstructMacroResult variant");
+            }
+        };
+        let parameters = get_response_model(parsed_model);
+
+        let expected_parameters = chat_completion::FunctionParameters {
+            schema_type: chat_completion::JSONSchemaType::Object,
+            properties: Some({
+                let mut props = std::collections::HashMap::new();
+                props.insert(
+                    "name".to_string(),
+                    Box::new(chat_completion::JSONSchemaDefine {
+                        schema_type: Some(chat_completion::JSONSchemaType::String),
+                        description: Some("The name of the user".to_string()),
+                        ..Default::default()
+                    }),
+                );
+                props.insert(
+                    "age".to_string(),
+                    Box::new(chat_completion::JSONSchemaDefine {
+                        schema_type: Some(chat_completion::JSONSchemaType::Number),
+                        description: Some("The age of the user".to_string()),
+                        ..Default::default()
+                    }),
+                );
+                props
+            }),
+            required: Some(vec!["name".to_string()]), // Only "name" should be required
+        };
+
+        assert_eq!(expected_parameters, parameters);
+    }
+
+    #[test]
+    fn test_struct_with_nested_optional_field() {
+        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
+        struct User {
+            name: String,
+            age: u8,
+        }
+
+        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
+        struct MaybeUser {
+            user: Option<User>,
+        }
+
+        let struct_info = MaybeUser::get_info();
+        let parsed_model: StructInfo = match struct_info {
+            InstructMacroResult::Struct(info) => info,
+            _ => {
+                panic!("Expected StructInfo but got a different InstructMacroResult variant");
+            }
+        };
+        let parameters = get_response_model(parsed_model);
+
+        let expected_parameters = chat_completion::FunctionParameters {
+            schema_type: chat_completion::JSONSchemaType::Object,
+            properties: Some({
+                let mut props = std::collections::HashMap::new();
+                props.insert(
+                    "user".to_string(),
+                    Box::new(chat_completion::JSONSchemaDefine {
+                        schema_type: Some(chat_completion::JSONSchemaType::Object),
+                        description: Some("".to_string()),
+                        properties: Some({
+                            let mut user_props = std::collections::HashMap::new();
+                            user_props.insert(
+                                "name".to_string(),
+                                Box::new(chat_completion::JSONSchemaDefine {
+                                    schema_type: Some(chat_completion::JSONSchemaType::String),
+                                    description: Some("".to_string()),
+                                    ..Default::default()
+                                }),
+                            );
+                            user_props.insert(
+                                "age".to_string(),
+                                Box::new(chat_completion::JSONSchemaDefine {
+                                    schema_type: Some(chat_completion::JSONSchemaType::Number),
+                                    description: Some("".to_string()),
+                                    ..Default::default()
+                                }),
+                            );
+                            user_props
+                        }),
+                        ..Default::default()
+                    }),
+                );
+                props
+            }),
+            required: Some(vec![]), // No required fields
+        };
+
         assert_eq!(expected_parameters, parameters);
     }
 }

--- a/instructor/tests/test_option.rs
+++ b/instructor/tests/test_option.rs
@@ -1,0 +1,54 @@
+extern crate instruct_macros;
+extern crate instruct_macros_types;
+
+use instruct_macros::InstructMacro;
+use instruct_macros_types::{Parameter, ParameterInfo, StructInfo};
+use instructor_ai::from_openai;
+use openai_api_rs::v1::api::Client;
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use openai_api_rs::v1::{
+        chat_completion::{self, ChatCompletionRequest},
+        common::GPT4_O,
+    };
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[test]
+    fn test_from_openai() {
+        let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
+        let instructor_client = from_openai(client);
+
+        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
+        struct UserInfo {
+            name: String,
+            age: u8,
+        }
+
+        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
+        struct MaybeUser {
+            #[description("This is an optional user field. If the user is not present, the field will be null")]
+            user: Option<UserInfo>,
+        }
+
+        let req = ChatCompletionRequest::new(
+            GPT4_O.to_string(),
+            vec![chat_completion::ChatCompletionMessage {
+                role: chat_completion::MessageRole::user,
+                content: chat_completion::Content::Text(String::from("It's a beautiful day out")),
+                name: None,
+            }],
+        );
+
+        let result = instructor_client
+            .chat_completion::<MaybeUser>(req, 3)
+            .unwrap();
+
+        println!("{:?}", result);
+        // assert!(result.user.is_none());
+    }
+}

--- a/instructor/tests/test_option.rs
+++ b/instructor/tests/test_option.rs
@@ -48,7 +48,6 @@ mod tests {
             .chat_completion::<MaybeUser>(req, 3)
             .unwrap();
 
-        println!("{:?}", result);
-        // assert!(result.user.is_none());
+        assert!(result.user.is_none());
     }
 }


### PR DESCRIPTION
We can now support option types with this new PR

```rust
let client = Client::new(env::var("OPENAI_API_KEY").unwrap().to_string());
        let instructor_client = from_openai(client);

        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
        struct UserInfo {
            name: String,
            age: u8,
        }

        #[derive(InstructMacro, Debug, Serialize, Deserialize)]
        struct MaybeUser {
            #[description("This is an optional user field. If the user is not present, the field will be null")]
            user: Option<UserInfo>,
        }

        let req = ChatCompletionRequest::new(
            GPT4_O.to_string(),
            vec![chat_completion::ChatCompletionMessage {
                role: chat_completion::MessageRole::user,
                content: chat_completion::Content::Text(String::from("It's a beautiful day out")),
                name: None,
            }],
        );

        let result = instructor_client
            .chat_completion::<MaybeUser>(req, 3)
            .unwrap();

        assert!(result.user.is_none());
```